### PR TITLE
Refactor to allow dom id's to be specified by client js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist/
 node_modules/
 
 .DS_Store
+Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ dist/
 node_modules/
 
 .DS_Store
-Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,6 @@ dependencies = [
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdweb 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "stdweb-derive 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,10 @@ version = "0.2.4"
 dependencies = [
  "gameboy_opengl 0.2.4",
  "gameboy_opengl_web 0.2.4",
+ "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdweb 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stdweb-derive 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,7 @@ dependencies = [
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdweb 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdweb-derive 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "webgl_generator 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1205,6 +1206,8 @@ version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen-macro 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "gameboy_emulator"
 version = "0.2.4"
-authors = ["Benjamin Konz <benkonz@protonmail.com>"]
+authors = ["Benjamin Konz <benkonz@protonmail.com>","Nicholas Alexeev <scifi6546@protonmail.com"]
 edition = "2018"
 
 [dependencies]
@@ -9,7 +9,10 @@ edition = "2018"
 [target.wasm32-unknown-unknown.dependencies]
 gameboy_opengl_web = { path = "gameboy_opengl_web", version = "0.2.4" }
 stdweb = "0.4"
+stdweb-derive="0.5.3"
 
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+serde_derive = "1.0.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 gameboy_opengl = { path = "gameboy_opengl", version = "0.2.4" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 [target.wasm32-unknown-unknown.dependencies]
 gameboy_opengl_web = { path = "gameboy_opengl_web", version = "0.2.4" }
 stdweb = "0.4"
-
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_derive = "1.0.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 [target.wasm32-unknown-unknown.dependencies]
 gameboy_opengl_web = { path = "gameboy_opengl_web", version = "0.2.4" }
 stdweb = "0.4"
-stdweb-derive="0.5.3"
 
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 serde_derive = "1.0.0"

--- a/gameboy_opengl_web/Cargo.toml
+++ b/gameboy_opengl_web/Cargo.toml
@@ -16,4 +16,3 @@ wasm-bindgen = {version="0.2.58",features=["serde-serialize"]}
 
 [build-dependencies]
 webgl_generator = "0.2"
-

--- a/gameboy_opengl_web/Cargo.toml
+++ b/gameboy_opengl_web/Cargo.toml
@@ -12,6 +12,8 @@ serde = "1.0"
 serde_derive = "1.0"
 stdweb-derive = "0.5"
 gameboy_core = { path = "../gameboy_core", version = "0.2.9" }
+wasm-bindgen = {version="0.2.58",features=["serde-serialize"]}
 
 [build-dependencies]
 webgl_generator = "0.2"
+

--- a/gameboy_opengl_web/src/lib.rs
+++ b/gameboy_opengl_web/src/lib.rs
@@ -210,6 +210,7 @@ pub struct DOMInfo{
     pub b_button_id:String,
     pub start_button_id:String,
     pub select_button_id:String,
+    pub canvas_id:String,
 }
 pub fn start(rom: Vec<u8>,dom_ids: DOMInfo) {
     let (sender, receiver) = mpsc::channel();
@@ -286,7 +287,7 @@ pub fn start(rom: Vec<u8>,dom_ids: DOMInfo) {
     });
 
     let canvas: CanvasElement = document()
-        .get_element_by_id("canvas")
+        .get_element_by_id(dom_ids.canvas_id.as_str())
         .unwrap()
         .try_into()
         .unwrap();

--- a/gameboy_opengl_web/src/lib.rs
+++ b/gameboy_opengl_web/src/lib.rs
@@ -196,50 +196,62 @@ impl EmulatorState {
             }));
     }
 }
-#[derive(Deserialize,Serialize)]
-pub struct DOMInfo{
-    pub up_button_id:String,
-    pub down_button_id:String,
-    pub left_button_id:String,
-    pub right_button_id:String,
-    pub up_left_button_id:String,
-    pub up_right_button_id:String,
-    pub down_left_button_id:String,
-    pub down_right_button_id:String,
-    pub a_button_id:String,
-    pub b_button_id:String,
-    pub start_button_id:String,
-    pub select_button_id:String,
-    pub canvas_id:String,
+#[derive(Deserialize, Serialize)]
+pub struct DOMInfo {
+    up_button_id: String,
+    down_button_id: String,
+    left_button_id: String,
+    right_button_id: String,
+    up_left_button_id: String,
+    up_right_button_id: String,
+    down_left_button_id: String,
+    down_right_button_id: String,
+    a_button_id: String,
+    b_button_id: String,
+    start_button_id: String,
+    select_button_id: String,
+    canvas_id: String,
 }
-pub fn start(rom: Vec<u8>,dom_ids: DOMInfo) {
+pub fn start(rom: Vec<u8>, dom_ids: DOMInfo) {
     let (sender, receiver) = mpsc::channel();
     let should_save_to_local = Rc::new(RefCell::new(false));
 
-    let up_btn = document().get_element_by_id(
-        dom_ids.up_button_id.as_str()).unwrap();
-    let down_btn = document().get_element_by_id(
-        dom_ids.down_button_id.as_str()).unwrap();
-    let left_btn = document().get_element_by_id(
-        dom_ids.left_button_id.as_str()).unwrap();
-    let right_btn = document().get_element_by_id(
-        dom_ids.right_button_id.as_str()).unwrap();
-    let up_left_btn = document().get_element_by_id(
-        dom_ids.up_left_button_id.as_str()).unwrap();
-    let up_right_btn = document().get_element_by_id(
-        dom_ids.up_right_button_id.as_str()).unwrap();
-    let down_left_btn = document().get_element_by_id(
-        dom_ids.down_left_button_id.as_str()).unwrap();
-    let down_right_btn = document().get_element_by_id(
-        dom_ids.down_right_button_id.as_str()).unwrap();
-    let a_btn = document().get_element_by_id(
-        dom_ids.a_button_id.as_str()).unwrap();
-    let b_btn = document().get_element_by_id(
-        dom_ids.b_button_id.as_str()).unwrap();
-    let start_btn = document().get_element_by_id(
-        dom_ids.start_button_id.as_str()).unwrap();
-    let select_btn = document().get_element_by_id(
-        dom_ids.select_button_id.as_str()).unwrap();
+    let up_btn = document()
+        .get_element_by_id(dom_ids.up_button_id.as_str())
+        .unwrap();
+    let down_btn = document()
+        .get_element_by_id(dom_ids.down_button_id.as_str())
+        .unwrap();
+    let left_btn = document()
+        .get_element_by_id(dom_ids.left_button_id.as_str())
+        .unwrap();
+    let right_btn = document()
+        .get_element_by_id(dom_ids.right_button_id.as_str())
+        .unwrap();
+    let up_left_btn = document()
+        .get_element_by_id(dom_ids.up_left_button_id.as_str())
+        .unwrap();
+    let up_right_btn = document()
+        .get_element_by_id(dom_ids.up_right_button_id.as_str())
+        .unwrap();
+    let down_left_btn = document()
+        .get_element_by_id(dom_ids.down_left_button_id.as_str())
+        .unwrap();
+    let down_right_btn = document()
+        .get_element_by_id(dom_ids.down_right_button_id.as_str())
+        .unwrap();
+    let a_btn = document()
+        .get_element_by_id(dom_ids.a_button_id.as_str())
+        .unwrap();
+    let b_btn = document()
+        .get_element_by_id(dom_ids.b_button_id.as_str())
+        .unwrap();
+    let start_btn = document()
+        .get_element_by_id(dom_ids.start_button_id.as_str())
+        .unwrap();
+    let select_btn = document()
+        .get_element_by_id(dom_ids.select_button_id.as_str())
+        .unwrap();
 
     add_button_event_listeners(&up_btn, Button::Up, sender.clone());
     add_button_event_listeners(&down_btn, Button::Down, sender.clone());

--- a/gameboy_opengl_web/src/lib.rs
+++ b/gameboy_opengl_web/src/lib.rs
@@ -196,7 +196,7 @@ impl EmulatorState {
             }));
     }
 }
-#[derive(Serialize)]
+#[derive(Deserialize,Serialize)]
 pub struct DOMInfo{
     pub up_button_id:String,
     pub down_button_id:String,

--- a/gameboy_opengl_web/src/lib.rs
+++ b/gameboy_opengl_web/src/lib.rs
@@ -196,23 +196,49 @@ impl EmulatorState {
             }));
     }
 }
-
-pub fn start(rom: Vec<u8>) {
+#[derive(Serialize)]
+pub struct DOMInfo{
+    pub up_button_id:String,
+    pub down_button_id:String,
+    pub left_button_id:String,
+    pub right_button_id:String,
+    pub up_left_button_id:String,
+    pub up_right_button_id:String,
+    pub down_left_button_id:String,
+    pub down_right_button_id:String,
+    pub a_button_id:String,
+    pub b_button_id:String,
+    pub start_button_id:String,
+    pub select_button_id:String,
+}
+pub fn start(rom: Vec<u8>,dom_ids: DOMInfo) {
     let (sender, receiver) = mpsc::channel();
     let should_save_to_local = Rc::new(RefCell::new(false));
 
-    let up_btn = document().get_element_by_id("up-btn").unwrap();
-    let down_btn = document().get_element_by_id("down-btn").unwrap();
-    let left_btn = document().get_element_by_id("left-btn").unwrap();
-    let right_btn = document().get_element_by_id("right-btn").unwrap();
-    let up_left_btn = document().get_element_by_id("up-left-btn").unwrap();
-    let up_right_btn = document().get_element_by_id("up-right-btn").unwrap();
-    let down_left_btn = document().get_element_by_id("down-left-btn").unwrap();
-    let down_right_btn = document().get_element_by_id("down-right-btn").unwrap();
-    let a_btn = document().get_element_by_id("a-btn").unwrap();
-    let b_btn = document().get_element_by_id("b-btn").unwrap();
-    let start_btn = document().get_element_by_id("start-btn").unwrap();
-    let select_btn = document().get_element_by_id("select-btn").unwrap();
+    let up_btn = document().get_element_by_id(
+        dom_ids.up_button_id.as_str()).unwrap();
+    let down_btn = document().get_element_by_id(
+        dom_ids.down_button_id.as_str()).unwrap();
+    let left_btn = document().get_element_by_id(
+        dom_ids.left_button_id.as_str()).unwrap();
+    let right_btn = document().get_element_by_id(
+        dom_ids.right_button_id.as_str()).unwrap();
+    let up_left_btn = document().get_element_by_id(
+        dom_ids.up_left_button_id.as_str()).unwrap();
+    let up_right_btn = document().get_element_by_id(
+        dom_ids.up_right_button_id.as_str()).unwrap();
+    let down_left_btn = document().get_element_by_id(
+        dom_ids.down_left_button_id.as_str()).unwrap();
+    let down_right_btn = document().get_element_by_id(
+        dom_ids.down_right_button_id.as_str()).unwrap();
+    let a_btn = document().get_element_by_id(
+        dom_ids.a_button_id.as_str()).unwrap();
+    let b_btn = document().get_element_by_id(
+        dom_ids.b_button_id.as_str()).unwrap();
+    let start_btn = document().get_element_by_id(
+        dom_ids.start_button_id.as_str()).unwrap();
+    let select_btn = document().get_element_by_id(
+        dom_ids.select_button_id.as_str()).unwrap();
 
     add_button_event_listeners(&up_btn, Button::Up, sender.clone());
     add_button_event_listeners(&down_btn, Button::Down, sender.clone());

--- a/gameboy_opengl_web/src/lib.rs
+++ b/gameboy_opengl_web/src/lib.rs
@@ -196,7 +196,7 @@ impl EmulatorState {
             }));
     }
 }
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct DOMInfo {
     up_button_id: String,
     down_button_id: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,8 @@ use stdweb::js_export;
 #[cfg(target_arch = "wasm32")]
 use stdweb::JsSerialize;
 
-
 #[cfg(not(target_arch = "wasm32"))]
 extern crate gameboy_opengl;
-
 
 /// # Safety
 ///
@@ -27,13 +25,12 @@ pub unsafe fn start(pointer: *mut u8, length: usize) {
 
 #[cfg(target_arch = "wasm32")]
 #[js_export]
-pub fn start(rom: Vec<u8>,dom_ids: String) {
+pub fn start(rom: Vec<u8>, dom_ids: String) {
     let res = serde_json::from_str(dom_ids.as_str());
-    if res.is_ok(){
-        
-        gameboy_opengl_web::start(rom,res.ok().unwrap());
-    }else{
-        js!{
+    if res.is_ok() {
+        gameboy_opengl_web::start(rom, res.ok().unwrap());
+    } else {
+        js! {
             console.log("bad parse");
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,16 @@ extern crate gameboy_opengl_web;
 #[cfg(target_arch = "wasm32")]
 pub use gameboy_opengl_web::DOMInfo;
 #[cfg(target_arch = "wasm32")]
+#[macro_use]
 extern crate stdweb;
 #[cfg(target_arch = "wasm32")]
 use stdweb::js_export;
+#[cfg(target_arch = "wasm32")]
+use stdweb::JsSerialize;
+
 
 #[cfg(not(target_arch = "wasm32"))]
 extern crate gameboy_opengl;
-
 
 
 /// # Safety
@@ -24,6 +27,17 @@ pub unsafe fn start(pointer: *mut u8, length: usize) {
 
 #[cfg(target_arch = "wasm32")]
 #[js_export]
-fn start(rom: Vec<u8>,dom_ids: DOMInfo) {
-    gameboy_opengl_web::start(rom,dom_ids);
+pub fn start(rom: Vec<u8>,dom_ids: String) {
+    js!{
+        alert("hello?");
+    }
+    let res = serde_json::from_str(dom_ids.as_str());
+    if res.is_ok(){
+        
+        gameboy_opengl_web::start(rom,res.ok().unwrap());
+    }else{
+        js!{
+            alert("bad parse");
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,9 @@ pub unsafe fn start(pointer: *mut u8, length: usize) {
 #[cfg(target_arch = "wasm32")]
 #[js_export]
 pub fn start(rom: Vec<u8>, dom_ids: String) {
-    match serde_json::from_str(dom_ids.as_str()){
-        Ok(dom_info)=>gameboy_opengl_web::start(rom, dom_info),
-        Err(err)=>{
+    match serde_json::from_str(dom_ids.as_str()) {
+        Ok(dom_info) => gameboy_opengl_web::start(rom, dom_info),
+        Err(err) => {
             let msg = format!("{:?}", err);
             console!(log, "bad parse: ", msg);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,6 @@ pub use gameboy_opengl_web::DOMInfo;
 extern crate stdweb;
 #[cfg(target_arch = "wasm32")]
 use stdweb::js_export;
-#[cfg(target_arch = "wasm32")]
-use stdweb::JsSerialize;
 
 #[cfg(not(target_arch = "wasm32"))]
 extern crate gameboy_opengl;
@@ -26,12 +24,11 @@ pub unsafe fn start(pointer: *mut u8, length: usize) {
 #[cfg(target_arch = "wasm32")]
 #[js_export]
 pub fn start(rom: Vec<u8>, dom_ids: String) {
-    let res = serde_json::from_str(dom_ids.as_str());
-    if res.is_ok() {
-        gameboy_opengl_web::start(rom, res.ok().unwrap());
-    } else {
-        js! {
-            console.log("bad parse");
+    match serde_json::from_str(dom_ids.as_str()){
+        Ok(dom_info)=>gameboy_opengl_web::start(rom, dom_info),
+        Err(err)=>{
+            let msg = format!("{:?}", err);
+            console!(log, "bad parse: ", msg);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,16 @@
 #[cfg(target_arch = "wasm32")]
 extern crate gameboy_opengl_web;
 #[cfg(target_arch = "wasm32")]
+pub use gameboy_opengl_web::DOMInfo;
+#[cfg(target_arch = "wasm32")]
 extern crate stdweb;
 #[cfg(target_arch = "wasm32")]
 use stdweb::js_export;
 
 #[cfg(not(target_arch = "wasm32"))]
 extern crate gameboy_opengl;
+
+
 
 /// # Safety
 ///
@@ -20,6 +24,6 @@ pub unsafe fn start(pointer: *mut u8, length: usize) {
 
 #[cfg(target_arch = "wasm32")]
 #[js_export]
-fn start(rom: Vec<u8>) {
-    gameboy_opengl_web::start(rom);
+fn start(rom: Vec<u8>,dom_ids: DOMInfo) {
+    gameboy_opengl_web::start(rom,dom_ids);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,16 +28,13 @@ pub unsafe fn start(pointer: *mut u8, length: usize) {
 #[cfg(target_arch = "wasm32")]
 #[js_export]
 pub fn start(rom: Vec<u8>,dom_ids: String) {
-    js!{
-        alert("hello?");
-    }
     let res = serde_json::from_str(dom_ids.as_str());
     if res.is_ok(){
         
         gameboy_opengl_web::start(rom,res.ok().unwrap());
     }else{
         js!{
-            alert("bad parse");
+            console.log("bad parse");
         }
     }
 }

--- a/static/index.html
+++ b/static/index.html
@@ -68,7 +68,7 @@
     							start_button_id:"start-btn",
     							select_button_id:"select-btn",
 							}
-							emulator.start(rom);
+							emulator.start(rom,JSON.stringify(dom_info));
 						};
 
 						reader.readAsArrayBuffer(this.files[0]);

--- a/static/index.html
+++ b/static/index.html
@@ -55,18 +55,12 @@
 							const bytes = new Uint8Array(arrayBuffer);
 							const rom = Array.prototype.slice.call(bytes);
 							let dom_info = {
-    							up_button_id:"up-btn",
-    							down_button_id:"down-btn",
-    							left_button_id:"left-btn",
-    							right_button_id:"right-btn",
-    							up_left_button_id:"up-left-btn",
-    							up_right_button_id:"up-right-btn",
-    							down_left_button_id:"down-left-btn",
-    							down_right_button_id:"down-right-btn",
-    							a_button_id:"a-btn",
-    							b_button_id:"b-btn",
-    							start_button_id:"start-btn",
-								select_button_id:"select-btn",
+    							up_button_id:"up-btn", down_button_id:"down-btn",
+    							left_button_id:"left-btn", right_button_id:"right-btn",
+    							up_left_button_id:"up-left-btn", up_right_button_id:"up-right-btn",
+    							down_left_button_id:"down-left-btn", down_right_button_id:"down-right-btn",
+    							a_button_id:"a-btn", b_button_id:"b-btn",
+    							start_button_id:"start-btn", select_button_id:"select-btn",
 								canvas_id:"canvas",
 							}
 							emulator.start(rom,JSON.stringify(dom_info));

--- a/static/index.html
+++ b/static/index.html
@@ -66,7 +66,8 @@
     							a_button_id:"a-btn",
     							b_button_id:"b-btn",
     							start_button_id:"start-btn",
-    							select_button_id:"select-btn",
+								select_button_id:"select-btn",
+								canvas_id:"canvas",
 							}
 							emulator.start(rom,JSON.stringify(dom_info));
 						};

--- a/static/index.html
+++ b/static/index.html
@@ -54,6 +54,20 @@
 							const arrayBuffer = this.result;
 							const bytes = new Uint8Array(arrayBuffer);
 							const rom = Array.prototype.slice.call(bytes);
+							let dom_info = {
+    							up_button_id:"up-btn",
+    							down_button_id:"down-btn",
+    							left_button_id:"left-btn",
+    							right_button_id:"right-btn",
+    							up_left_button_id:"up-left-btn",
+    							up_right_button_id:"up-right-btn",
+    							down_left_button_id:"down-left-btn",
+    							down_right_button_id:"down-right-btn",
+    							a_button_id:"a-btn",
+    							b_button_id:"b-btn",
+    							start_button_id:"start-btn",
+    							select_button_id:"select-btn",
+							}
 							emulator.start(rom);
 						};
 


### PR DESCRIPTION
I am trying to refactor the emulator to work with external js frameworks and I think that allowing the DOM id's would be a first step in my process. I plan on having more pull requests to integerate the emulator with npm.