### PR TITLE
Add plumbing for serial data transfer

### DIFF
--- a/gameboy_core/src/emulator/mod.rs
+++ b/gameboy_core/src/emulator/mod.rs
@@ -10,6 +10,7 @@ use crate::mmu::cartridge::Cartridge;
 use crate::mmu::interrupt::Interrupt;
 use crate::mmu::Memory;
 use crate::timer::Timer;
+use crate::transfer::ByteTransfer;
 
 pub struct Emulator {
     cpu: Cpu,
@@ -33,12 +34,14 @@ impl Emulator {
         &mut self,
         system: &mut impl PixelMapper,
         controller: &mut Controller,
+        link_cable: &mut dyn ByteTransfer,
     ) -> StepResult {
         let cycles = self.cpu.step(&mut self.memory);
         self.timer.update(cycles, &mut self.memory);
         let audio_buffer_full = self.memory.get_sound_mut().step(cycles);
         let vblank = self.gpu.step(cycles, &mut self.memory, system);
         controller.update(&mut self.memory);
+        link_cable.update(cycles, &mut self.memory);
         self.handle_interrupts();
 
         if audio_buffer_full {

--- a/gameboy_core/src/transfer.rs
+++ b/gameboy_core/src/transfer.rs
@@ -1,0 +1,44 @@
+use crate::mmu::Memory;
+use crate::mmu::interrupt::Interrupt;
+
+pub trait ByteTransfer {
+
+    fn transfer(&mut self, cs: i32, sd: u8, sc: u8) -> Option<(u8, u8)>;
+
+    fn disconnected(&self) -> bool;
+
+    fn update(&mut self, cycles: i32, mmu: &mut Memory) {
+        let result = self.transfer(
+            cycles,
+            mmu.read_byte(0xFF01),
+            mmu.read_byte(0xFF02)
+        );
+
+        if self.disconnected() {
+            mmu.write_byte(0xFF01, 0xFF);
+        }
+
+        if let Some((data, control)) = result {
+            mmu.write_byte(0xFF01, data);
+            mmu.write_byte(0xFF02, control);
+
+            mmu.request_interrupt(Interrupt::Serial);
+        }
+    }
+}
+
+pub struct Unlinked;
+
+impl ByteTransfer for Unlinked {
+    fn transfer(&mut self, _: i32, _: u8, _: u8) -> Option<(u8, u8)> {
+        None
+    }
+
+    fn disconnected(&self) -> bool {
+        true
+    }
+
+    // update is sealed in crate external impls
+    fn update(&mut self, _cycles: i32, _mmu: &mut Memory) {
+    }
+}

--- a/gameboy_opengl/src/lib.rs
+++ b/gameboy_opengl/src/lib.rs
@@ -52,7 +52,8 @@ pub fn start(rom: Vec<u8>) -> Result<(), String> {
     canvas.clear();
 
     let rtc = Box::new(NativeRTC::new());
-    let mut emulator = Gameboy::from_rom(rom, rtc)?;
+    let slc = Box::new(gameboy_core::Unlinked);
+    let mut emulator = Gameboy::from_rom(rom, rtc, slc)?;
 
     load_ram_save_data(emulator.get_cartridge_mut()).map_err(|e| format!("{:?}", e))?;
     load_timestamp_data(emulator.get_cartridge_mut()).map_err(|e| format!("{:?}", e))?;

--- a/gameboy_opengl_web/src/lib.rs
+++ b/gameboy_opengl_web/src/lib.rs
@@ -268,7 +268,8 @@ pub fn start(rom: Vec<u8>, dom_ids: DOMInfo) -> Result<(), String> {
         return h;
     };
     let rtc = Box::new(WebRTC::new());
-    let mut gameboy = Gameboy::from_rom(rom, rtc)?;
+    let slc = Box::new(gameboy_core::Unlinked);
+    let mut gameboy = Gameboy::from_rom(rom, rtc, slc)?;
     load_ram_save_data(gameboy.get_cartridge_mut());
     load_timestamp_data(gameboy.get_cartridge_mut());
     let ram = gameboy.get_cartridge().get_ram().to_vec();


### PR DESCRIPTION
Provides an interface to emulate [serial data transfer](https://gbdev.io/pandocs/Serial_Data_Transfer_(Link_Cable).html). This [PoC](https://github.com/justincredible/gameboy_emulator/tree/link-cable-poc) shows the interface is sufficient to implement a generic transfer.

The functionality here could also be provided via public functions that:
- read/write the serial transfer memory locations
- raise a serial interrupt

but a bad implementation can cause poor UX either way.

I updated the web crate, but `cargo-web deploy --release` was failing on the master branch, so it was not tested. I'm also not sure how `./src/lib.rs` fits in; the file was not updated and there are no issues with building or running the native emulator.